### PR TITLE
1、增加多种协议复用同一端口功能（暂时只实现了socks5和http-get的协议识别和路由），用来更好的伪装代理端口。2、优化代理交换数据逻辑（当socks5协议协商完毕后去除掉链路中无用的编码器和解码器）。

### DIFF
--- a/socks-client/src/main/java/com/wh/network/mouse/socks/client/handler/Socks5CommandRequestHandler.java
+++ b/socks-client/src/main/java/com/wh/network/mouse/socks/client/handler/Socks5CommandRequestHandler.java
@@ -10,6 +10,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5CommandType;
 import io.netty.handler.ssl.SslContext;
 
@@ -38,8 +39,9 @@ public class Socks5CommandRequestHandler extends SimpleChannelInboundHandler<Def
 
             ChannelFuture channelFuture = bootstrap.connect(msg.dstAddr(), msg.dstPort());
             channelFuture.addListener(new ClientToRemoteListener(ctx, msg));
+            ctx.pipeline().remove(this).remove(Socks5CommandRequestDecoder.class);
         } else {
-            ctx.fireChannelRead(msg);
+            ctx.close();
         }
     }
 }

--- a/socks-client/src/main/java/com/wh/network/mouse/socks/client/handler/Socks5InitialRequestHandler.java
+++ b/socks-client/src/main/java/com/wh/network/mouse/socks/client/handler/Socks5InitialRequestHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
 import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5InitialResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +19,7 @@ public class Socks5InitialRequestHandler extends SimpleChannelInboundHandler<Def
         if (msg.decoderResult().isSuccess()) {
             Socks5InitialResponse socks5InitialResponse = new DefaultSocks5InitialResponse(Socks5AuthMethod.NO_AUTH);
             ctx.writeAndFlush(socks5InitialResponse);
-            ctx.pipeline().remove(this);
+            ctx.pipeline().remove(this).remove(Socks5InitialRequestDecoder.class);
         } else {
             log.info("解析socks5协议失败，详细信息：{}", msg);
             ctx.close();

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/DisguisedHttpRequestHandler.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/DisguisedHttpRequestHandler.java
@@ -1,0 +1,21 @@
+package com.wh.network.mouse.socks.server.handler;
+
+import com.wh.network.mouse.util.ConfigConstants;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class DisguisedHttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) throws Exception {
+        DefaultFullHttpResponse defaultFullHttpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.MOVED_PERMANENTLY);
+        defaultFullHttpResponse.headers().add(HttpHeaders.Names.LOCATION, ConfigConstants.MOVED_PERMANENTLY_URL);
+        ctx.writeAndFlush(defaultFullHttpResponse);
+        ctx.close();
+    }
+}

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/ProtocolRecognitionDecoder.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/ProtocolRecognitionDecoder.java
@@ -1,0 +1,66 @@
+package com.wh.network.mouse.socks.server.handler;
+
+import com.wh.network.mouse.handler.ExceptionCaughtHandler;
+import com.wh.network.mouse.socks.server.config.ServerConfig;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+public class ProtocolRecognitionDecoder extends ByteToMessageDecoder {
+
+    private ServerConfig serverConfig;
+
+    private EventLoopGroup proxy;
+
+    public ProtocolRecognitionDecoder(ServerConfig serverConfig, EventLoopGroup proxy) {
+        this.serverConfig = serverConfig;
+        this.proxy = proxy;
+    }
+
+    private static final byte SOCKS5 = '\u0005';
+
+    private static final byte HTTP = 'G';
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        if (in.readableBytes() >= 1) {
+            switch (in.getByte(0)) {
+                case SOCKS5:
+                    ctx.pipeline().addLast(
+                            Socks5ServerEncoder.DEFAULT,
+                            new Socks5InitialRequestDecoder(),
+                            new Socks5InitialRequestHandler(),
+                            new Socks5PasswordAuthRequestDecoder(),
+                            new Socks5PasswordAuthRequestHandler(),
+                            new Socks5CommandRequestDecoder(),
+                            new Socks5CommandRequestHandler(proxy, NioSocketChannel.class, serverConfig));
+                    break;
+                case HTTP:
+                    ctx.pipeline().addLast(
+                            new HttpServerCodec(),
+                            new HttpObjectAggregator(1 << 10),
+                            new DisguisedHttpRequestHandler());
+                    break;
+                default:
+                    log.info("接收到支持协议范围之外的报文");
+                    ctx.close();
+                    return;
+            }
+            ctx.pipeline().addLast(new ExceptionCaughtHandler());
+            out.add(in.retain());
+            ctx.pipeline().remove(this);
+        }
+    }
+}

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/ServerChannelInitializerHandler.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/ServerChannelInitializerHandler.java
@@ -1,15 +1,9 @@
 package com.wh.network.mouse.socks.server.handler;
 
-import com.wh.network.mouse.handler.ExceptionCaughtHandler;
 import com.wh.network.mouse.socks.server.config.ServerConfig;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
-import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
-import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder;
-import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleStateHandler;
 
@@ -34,14 +28,6 @@ public class ServerChannelInitializerHandler extends ChannelInitializer {
         }
         ch.pipeline().addLast(
                 new IdleStateHandler(serverConfig.getReaderIdleTime(), serverConfig.getWriterIdleTime(), serverConfig.getAllIdleTime()),
-                Socks5ServerEncoder.DEFAULT,
-                new Socks5InitialRequestDecoder(),
-                new Socks5InitialRequestHandler(),
-                new Socks5PasswordAuthRequestDecoder(),
-                new Socks5PasswordAuthRequestHandler(),
-                new Socks5CommandRequestDecoder(),
-                new Socks5CommandRequestHandler(proxy, NioSocketChannel.class, serverConfig),
-                new ExceptionCaughtHandler()
-        );
+                new ProtocolRecognitionDecoder(serverConfig, proxy));
     }
 }

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5CommandRequestHandler.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5CommandRequestHandler.java
@@ -10,6 +10,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5CommandType;
 
 public class Socks5CommandRequestHandler extends SimpleChannelInboundHandler<DefaultSocks5CommandRequest> {
@@ -35,8 +36,9 @@ public class Socks5CommandRequestHandler extends SimpleChannelInboundHandler<Def
 
             ChannelFuture channelFuture = bootstrap.connect(msg.dstAddr(), msg.dstPort());
             channelFuture.addListener(new ClientToRemoteListener(ctx, msg));
+            ctx.pipeline().remove(this).remove(Socks5CommandRequestDecoder.class);
         } else {
-            ctx.fireChannelRead(msg);
+            ctx.close();
         }
     }
 }

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5InitialRequestHandler.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5InitialRequestHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
 import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5InitialResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +19,7 @@ public class Socks5InitialRequestHandler extends SimpleChannelInboundHandler<Def
         if (msg.decoderResult().isSuccess()) {
             Socks5InitialResponse socks5InitialResponse = new DefaultSocks5InitialResponse(Socks5AuthMethod.PASSWORD);
             ctx.writeAndFlush(socks5InitialResponse);
-            ctx.pipeline().remove(this);
+            ctx.pipeline().remove(this).remove(Socks5InitialRequestDecoder.class);
         } else {
             log.info("解析socks5协议失败，详细信息：{}", msg);
             ctx.close();

--- a/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5PasswordAuthRequestHandler.java
+++ b/socks-server/src/main/java/com/wh/network/mouse/socks/server/handler/Socks5PasswordAuthRequestHandler.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5PasswordAuthResponse;
+import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponse;
 import io.netty.handler.codec.socksx.v5.Socks5PasswordAuthStatus;
 import io.netty.handler.traffic.ChannelTrafficShapingHandler;
@@ -27,7 +28,7 @@ public class Socks5PasswordAuthRequestHandler extends SimpleChannelInboundHandle
                 ctx.pipeline().addFirst(new ChannelTrafficShapingHandler(userInfo.getWriteLimit() << 10,
                         userInfo.getReadLimit() << 10, userInfo.getCheckInterval() * 1000, userInfo.getMaxTime() * 1000));
             }
-            ctx.pipeline().remove(this);
+            ctx.pipeline().remove(this).remove(Socks5PasswordAuthRequestDecoder.class);
         } else {
             log.info("用户：{} 身份验证失败，详细信息：{}", msg.username(), msg);
             Socks5PasswordAuthResponse socks5PasswordAuthResponse = new DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus.FAILURE);

--- a/util/src/main/java/com/wh/network/mouse/handler/ClientToRemoteListener.java
+++ b/util/src/main/java/com/wh/network/mouse/handler/ClientToRemoteListener.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandRequest;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
 import io.netty.handler.codec.socksx.v5.Socks5CommandResponse;
 import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
+import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
 
 public class ClientToRemoteListener implements ChannelFutureListener {
 
@@ -28,5 +29,6 @@ public class ClientToRemoteListener implements ChannelFutureListener {
             commandResponse = new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, msg.dstAddrType());
         }
         ctx.writeAndFlush(commandResponse);
+        ctx.pipeline().remove(Socks5ServerEncoder.class);
     }
 }

--- a/util/src/main/java/com/wh/network/mouse/util/ConfigConstants.java
+++ b/util/src/main/java/com/wh/network/mouse/util/ConfigConstants.java
@@ -18,4 +18,6 @@ public class ConfigConstants {
     public static final String CLIENT_DEFAULT_CONFIG_FILE_PATH = CONFIG_PATH + CLIENT_DEFAULT_CONFIG_FILE_NAME;
     public static final String USER_DEFAULT_CONFIG_FILE_PATH = CONFIG_PATH + USER_DEFAULT_CONFIG_FILE_NAME;
     public static final String KEYSTORE_DEFAULT_CONFIG_FILE_PATH = CONFIG_PATH + KEYSTORE_DEFAULT_CONFIG_FILE_NAME;
+
+    public static final String MOVED_PERMANENTLY_URL = "https://github.com/wanghao123456/network-mouse";
 }


### PR DESCRIPTION
1、增加多种协议复用同一端口功能（暂时只实现了socks5和http-get的协议识别和路由），用来更好的伪装代理端口。
2、优化代理交换数据逻辑（当socks5协议协商完毕后去除掉链路中无用的编码器和解码器）。